### PR TITLE
Make PyTorch an optional dependency for the batched simulator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,16 @@ dependencies = [
     'pandas',
     'tqdm',
     'gymnasium',
-    'roma',           # For batched sim
-    'torch>=1.11.0',  # For batched sim
-    'torchdiffeq',    # For batched sim
-    'opt-einsum',     # For batched sim
     'timed_count',    # Only for ardupilot sitl example
 ]
 
 [project.optional-dependencies]
+batched = [
+    'torch>=1.11.0',
+    'torchdiffeq',
+    'roma',
+    'opt-einsum',
+]
 learning = [
     'stable_baselines3',
     'tensorboard',
@@ -58,6 +60,10 @@ px4 = [
     'pymavlink',
 ]
 all = [
+    "torch>=1.11.0",
+    "torchdiffeq",
+    "roma",
+    "opt-einsum",
     "stable_baselines3",
     "tensorboard",
     "pytest",

--- a/rotorpy/controllers/quadrotor_control.py
+++ b/rotorpy/controllers/quadrotor_control.py
@@ -1,6 +1,9 @@
 import numpy as np
-import torch
-import roma
+try:
+    import torch
+    import roma
+except ImportError:
+    pass
 from scipy.spatial.transform import Rotation
 
 class SE3Control(object):

--- a/rotorpy/sensors/imu.py
+++ b/rotorpy/sensors/imu.py
@@ -1,6 +1,9 @@
 import numpy as np
 from scipy.spatial.transform import Rotation
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 import copy
 
 class Imu:

--- a/rotorpy/simulate.py
+++ b/rotorpy/simulate.py
@@ -2,8 +2,11 @@ import time
 from enum import Enum
 import copy
 import numpy as np
-import roma
-import torch
+try:
+    import roma
+    import torch
+except ImportError:
+    pass
 from numpy.linalg import norm
 from scipy.spatial.transform import Rotation
 from time import perf_counter

--- a/rotorpy/trajectories/circular_traj.py
+++ b/rotorpy/trajectories/circular_traj.py
@@ -1,5 +1,8 @@
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 import sys
 
 class ThreeDCircularTraj(object):

--- a/rotorpy/trajectories/hover_traj.py
+++ b/rotorpy/trajectories/hover_traj.py
@@ -1,5 +1,8 @@
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 
 class HoverTraj(object):
     """

--- a/rotorpy/trajectories/lissajous_traj.py
+++ b/rotorpy/trajectories/lissajous_traj.py
@@ -1,5 +1,8 @@
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 
 """
 Lissajous curves are defined by trigonometric functions parameterized in time. 

--- a/rotorpy/trajectories/minsnap.py
+++ b/rotorpy/trajectories/minsnap.py
@@ -5,7 +5,10 @@ import numpy as np
 import cvxopt
 from scipy.linalg import block_diag
 from typing import List
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 
 def cvxopt_solve_qp(P, q, G=None, h=None, A=None, b=None):
     """

--- a/rotorpy/trajectories/traj_template.py
+++ b/rotorpy/trajectories/traj_template.py
@@ -2,7 +2,10 @@
 Imports
 """
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 
 class TrajTemplate(object):
     """

--- a/rotorpy/vehicles/multirotor.py
+++ b/rotorpy/vehicles/multirotor.py
@@ -8,9 +8,12 @@ from rotorpy.vehicles.hummingbird_params import quad_params
 from scipy.spatial.transform import Rotation as R
 
 # imports for Batched Dynamics
-import torch
-from torchdiffeq import odeint
-import roma
+try:
+    import torch
+    from torchdiffeq import odeint
+    import roma
+except ImportError:
+    pass
 
 import time
 

--- a/rotorpy/vehicles/px4_multirotor.py
+++ b/rotorpy/vehicles/px4_multirotor.py
@@ -285,8 +285,8 @@ class PX4Multirotor(Multirotor):
             fields_updated=updated_bitmask,
         )
 
-    def step(self, state, control, t_step):        
-        
+    def step(self, state, control, t_step):
+
         # Compute state derivative once for state and messages
         # and send both HIL messages
         statedot = self.statedot(state, control, 0.0)
@@ -298,14 +298,13 @@ class PX4Multirotor(Multirotor):
             px4_control = self._fetch_latest_px4_control(blocking=self._lockstep_enabled)
             if px4_control is not None:
                 self._last_control = px4_control
-                control = px4_control
             else:
-                control = self._last_control
+                pass # Do not modify _last_control
 
         else: # In this case we use the control provided by the external controller
-            pass
-        
-        state = super().step(state, control, t_step)
+            self._last_control = control
+
+        state = super().step(state, self._last_control, t_step)
         self.state = state
         self.t += t_step
 

--- a/rotorpy/wind/default_winds.py
+++ b/rotorpy/wind/default_winds.py
@@ -1,6 +1,9 @@
 import numpy as np
 import sys
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 import math
 import random
 

--- a/rotorpy/wind/dryden_winds.py
+++ b/rotorpy/wind/dryden_winds.py
@@ -1,5 +1,8 @@
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:
+    pass
 import os
 import sys
 


### PR DESCRIPTION
Move PyTorch and related packages to optional dependencies to prevent unnecessary installations for users who only need the standard simulator. Refine control handling in the PX4Multirotor step method to improve functionality.